### PR TITLE
Poprawki do poprawek cech

### DIFF
--- a/statystyka/cechy.lua
+++ b/statystyka/cechy.lua
@@ -162,7 +162,7 @@ function trigger_licznik_cech_cechy_func()
     --wytka
     --uciecie "jak na..."
     if string.find(wytrzymalosc, " ") then
-      if string.find(wytrzymalosc, " ") then
+      if string.find(wytrzymalosc, "dobrze zbudowan") then
         str = "dobrze zbudowan"
       else
        str = string.match(wytrzymalosc, '(.*) (.*) (.*) (.*) (.*)')


### PR DESCRIPTION
Każdą wytkę, która miała spację (więc wszystkie "jak na legende, półboga, boga" też) podstawiało dobrze zbudowany, wiec źle wyświetlało poziom. My bad.