### PR TITLE
Poprawka kolorowania ciosów zwierzaków i potworów. Dodanie gnomiej mowy. Podmiana postępów.

### DIFF
--- a/scriptsList.lua
+++ b/scriptsList.lua
@@ -43,6 +43,7 @@ return {
     "triggers/ekwipunek",
     "triggers/mowienie",
     "triggers/gonienie",
+    "triggers/podmiana",
     "http_client",
     "installer/latest",
     "installer/installer",

--- a/triggers/podmiana.lua
+++ b/triggers/podmiana.lua
@@ -1,0 +1,33 @@
+function podmiana_postepow_func()
+
+	local kolor_postepow = "gold"
+
+	local postepy = {
+		["znikome"] = 0,
+		["minimalne"] = 1,
+		["nieznaczne"] = 2,
+		["malutkie"] = 3,
+		["male"] = 4,
+		["nieduze"] = 5,
+		["spore"] = 6,
+		["znaczne"] = 7,
+		["pokazne"] = 8,
+		["duze"] = 9,
+		["wielkie"] = 10,
+		["wspaniale"] = 11,
+		["wysmienite"] = 12,
+		["ogromne"] = 13,
+		["gigantyczne"] = 14,
+		["kolosalne"] = 15,
+		["niesamowite"] = 16,
+		["fantastyczne"] = 17
+	}
+
+	local postepy_wartosc = postepy[matches[3]]
+
+	selectString(matches[3], 1)
+	fg(kolor_postepow)
+	replace(matches[3].. " (" ..postepy_wartosc.."/17)")
+	resetFormat()
+
+end

--- a/warlock_scripts.xml
+++ b/warlock_scripts.xml
@@ -2369,6 +2369,44 @@ resetFormat()</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
+				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>Podmiana</name>
+					<script></script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList />
+					<regexCodePropertyList />
+					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+						<name>podmiana_postepow</name>
+						<script>podmiana_postepow_func()</script>
+						<triggerType>0</triggerType>
+						<conditonLineDelta>0</conditonLineDelta>
+						<mStayOpen>0</mStayOpen>
+						<mCommand></mCommand>
+						<packageName></packageName>
+						<mFgColor>#ff0000</mFgColor>
+						<mBgColor>#ffff00</mBgColor>
+						<mSoundFile></mSoundFile>
+						<colorTriggerFgColor>#000000</colorTriggerFgColor>
+						<colorTriggerBgColor>#000000</colorTriggerBgColor>
+						<regexCodeList>
+							<string>^Wydaje ci sie ze poczyni(l|lo|la) (znikome|minimalne|nieznaczne|malutkie|male|nieduze|spore|znaczne|pokazne|duze|wielkie|wspaniale|wysmienite|ogromne|gigantyczne|kolosalne|niesamowite|fantastyczne) postepy jako najemnik.$</string>
+							<string>^Poczynil(es|as) (znikome|minimalne|nieznaczne|malutkie|male|nieduze|spore|znaczne|pokazne|duze|wielkie|wspaniale|wysmienite|ogromne|gigantyczne|kolosalne|niesamowite|fantastyczne) postepy, odkad pojawiles sie w tym swiecie.$</string>
+						</regexCodeList>
+						<regexCodePropertyList>
+							<integer>1</integer>
+							<integer>1</integer>
+						</regexCodePropertyList>
+					</Trigger>
+				</TriggerGroup>
 			</TriggerGroup>
 		</TriggerGroup>
 	</TriggerPackage>

--- a/warlock_scripts.xml
+++ b/warlock_scripts.xml
@@ -901,7 +901,7 @@
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
 						<string> trafiajac w </string>
-						<string> trafiajac (go|ja|je|jego) w </string>
+						<string> trafiajac (cie|go|ja|je|jego) w </string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>0</integer>
@@ -963,7 +963,7 @@
 						<colorTriggerFgColor>#000000</colorTriggerFgColor>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
-							<string>(.+) (ledwo muska|lekko rani|rani|powaznie rani|bardzo ciezko rani|potwornie rani|masakruje) (.+), trafiajac (cie|go|ja|je) w (.+).</string>
+							<string>(.+?) (ledwo muska|lekko rani|rani|powaznie rani|bardzo ciezko rani|potwornie rani|masakruje) (.+), trafiajac (cie|go|ja|je) w (.+).</string>
 						</regexCodeList>
 						<regexCodePropertyList>
 							<integer>1</integer>

--- a/warlock_scripts.xml
+++ b/warlock_scripts.xml
@@ -1928,7 +1928,7 @@
 						<string>Mowisz</string>
 						<string>Krzyczysz</string>
 						<string>Wrzeszczysz</string>
-						<string>mowi|dudni|szepce|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci</string>
+						<string>mowi|dudni|szepce|skrzeczy|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci</string>
 						<string>Szepczesz</string>
 					</regexCodeList>
 					<regexCodePropertyList>
@@ -1952,8 +1952,8 @@
 						<colorTriggerFgColor>#000000</colorTriggerFgColor>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
-							<string>(.+) (mowi|dudni|szepce|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci)()( do (.+)|): (.+)</string>
-							<string>(.+) (mowi|dudni|szepce|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci)( .*?|)( do (.+)|): (.+)</string>
+							<string>(.+) (mowi|dudni|szepce|skrzeczy|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci)()( do (.+)|): (.+)</string>
+							<string>(.+) (mowi|dudni|szepce|skrzeczy|warczy|zawodzi|spiewa|pomrukuje|piszczy|bulgocze|krzyczy|wrzeszczy|szepcze|mruczy|syczy|huczy|charczy|grzmi|nuci)( .*?|)( do (.+)|): (.+)</string>
 						</regexCodeList>
 						<regexCodePropertyList>
 							<integer>1</integer>


### PR DESCRIPTION
Bugfix.
Regexy nie wyłapywały właściwie ciosów od zwierząt.

![image](https://github.com/WarlockMud/mudlet-scripts/assets/31707119/5f947680-cffe-4b77-a585-bc094ca5e100)
![image](https://github.com/WarlockMud/mudlet-scripts/assets/31707119/991daada-c601-49fd-a097-c916b1015130)
![image](https://github.com/WarlockMud/mudlet-scripts/assets/31707119/175d4e4d-8a88-4876-a2de-b65e1f27aab3)
![image](https://github.com/WarlockMud/mudlet-scripts/assets/31707119/992f4ad5-2c24-412a-8a23-74037295befe)
