### PR TITLE
Drobna poprawka do procesowania walki

### DIFF
--- a/walka/walka.lua
+++ b/walka/walka.lua
@@ -10,7 +10,13 @@ end
 function scripts.walka:process_objects(objects)
 
     for k,v in pairs(scripts.walka.objects) do
-        if not table.contains(scripts.walka.nums, tonumber(k)) then
+		local remove = true;
+		for z,n in pairs(scripts.walka.nums) do
+			if tonumber(k) == n then
+				remove = false
+			end
+		end
+        if remove then
             scripts.walka.objects[k] = nil
             scripts.windows:hideEnemyStatsFor(tonumber(k))
         end


### PR DESCRIPTION
Poprawne czyszczenie obiektu walki, czasami dodawalo npca i nie usuwalo (balon karzeł), przez co sypaly sie aliasy do ataku bo podstawialo nie istniejacy obiekt.